### PR TITLE
横浜市立図書館蔵書検索ページにおける非表示の送信ボタン群は DOM から削除せず `<form>` 外に移動する

### DIFF
--- a/packages/userscript/dist/opac_lib_city_yokohama_lg_jp.user.js
+++ b/packages/userscript/dist/opac_lib_city_yokohama_lg_jp.user.js
@@ -3,7 +3,7 @@
 // @namespace   https://w0s.jp/
 // @description 「横浜市立図書館蔵書検索ページ」のフォーム操作を改善
 // @author      SaekiTominaga
-// @version     1.0.0
+// @version     1.0.1
 // @match       https://opac.lib.city.yokohama.lg.jp/winj/opac/*
 // ==/UserScript==
 (() => {
@@ -22,7 +22,15 @@
     const volumeListFormElement = document.getElementsByName('VolumeListForm')[0];
     if (volumeListFormElement !== undefined) {
         /* Enter キー押下で意図しない送信ボタンが submit されてしまうのを防止 */
-        volumeListFormElement.querySelector('div[style="display:none;"]')?.remove();
+        const hiddenSubmitsWrapElement = volumeListFormElement.querySelector('div[style="display:none;"]');
+        if (hiddenSubmitsWrapElement !== null) {
+            const FROM_ID = 'VolumeListForm';
+            volumeListFormElement.id = FROM_ID;
+            hiddenSubmitsWrapElement.querySelectorAll('input').forEach((inputElement) => {
+                inputElement.setAttribute('form', FROM_ID);
+            });
+            document.body.insertAdjacentElement('beforeend', hiddenSubmitsWrapElement);
+        }
         /* 正確な日付を指定する必要性は薄いため、年のみの指定で送信できるようにする */
         for (const originInputElement of volumeListFormElement.querySelectorAll('input[name="txt_stisdate"], input[name="txt_edisdate"]')) {
             originInputElement.hidden = true;

--- a/packages/userscript/src/opac_lib_city_yokohama_lg_jp.user.ts
+++ b/packages/userscript/src/opac_lib_city_yokohama_lg_jp.user.ts
@@ -3,7 +3,7 @@
 // @namespace   https://w0s.jp/
 // @description 「横浜市立図書館蔵書検索ページ」のフォーム操作を改善
 // @author      SaekiTominaga
-// @version     1.0.0
+// @version     1.0.1
 // @match       https://opac.lib.city.yokohama.lg.jp/winj/opac/*
 // ==/UserScript==
 (() => {
@@ -25,7 +25,17 @@
 	const volumeListFormElement = document.getElementsByName('VolumeListForm')[0];
 	if (volumeListFormElement !== undefined) {
 		/* Enter キー押下で意図しない送信ボタンが submit されてしまうのを防止 */
-		volumeListFormElement.querySelector('div[style="display:none;"]')?.remove();
+		const hiddenSubmitsWrapElement = volumeListFormElement.querySelector('div[style="display:none;"]');
+		if (hiddenSubmitsWrapElement !== null) {
+			const FROM_ID = 'VolumeListForm';
+
+			volumeListFormElement.id = FROM_ID;
+
+			hiddenSubmitsWrapElement.querySelectorAll('input').forEach((inputElement): void => {
+				inputElement.setAttribute('form', FROM_ID);
+			});
+			document.body.insertAdjacentElement('beforeend', hiddenSubmitsWrapElement);
+		}
 
 		/* 正確な日付を指定する必要性は薄いため、年のみの指定で送信できるようにする */
 		for (const originInputElement of volumeListFormElement.querySelectorAll<HTMLInputElement>('input[name="txt_stisdate"], input[name="txt_edisdate"]')) {


### PR DESCRIPTION
Enter キーによる送信ができないため非表示の送信ボタン群を `remove()` で DOM から消していたが、JavaScript で使用しているページが存在したため、`<form>` 要素の外に移動するように変更