### PR TITLE
横浜市立図書館蔵書検索ページのログイン状態における `#box-utility` のスタイル調整

### DIFF
--- a/packages/userstyle/style/opac_lib_city_yokohama_lg_jp.user.css
+++ b/packages/userstyle/style/opac_lib_city_yokohama_lg_jp.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           横浜市立図書館蔵書検索ページ
 @namespace      https://w0s.jp/
-@version        1.2.0
+@version        1.2.1
 @author         SaekiTominaga
 ==/UserStyle== */
 @-moz-document domain("opac.lib.city.yokohama.lg.jp") {
@@ -14,14 +14,23 @@
 		}
 	}
 
-	/* ログインリンクの枠線内の空き部分をクリッカブルにする */
 	#box-utility {
-		padding: 0;
+		/* ログイン状態での無駄なマージンを除去 */
+		& .list-linear:not(:has(li)) {
+			& + .list-linear {
+				margin-top: 0;
+			}
+		}
 
-		& .list-linear {
-			& a {
-				display: block flow;
-				padding: 10px;
+		/* ログインリンクの枠線内の空き部分をクリッカブルにする */
+		&:has(.list-linear:only-child) {
+			padding: 0;
+
+			& .list-linear:only-child {
+				& a {
+					display: block flow;
+					padding: 10px;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#22 の考慮漏れ修正